### PR TITLE
GitHub Actions: explicitly define python version with pipenv

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           env
           pip install pipenv
-          pipenv install --dev --deploy && pipenv graph
+          pipenv install --dev --deploy --python ${{ matrix.python }} && pipenv graph
 
       - name: Create Sdist and Wheel
         # for reproducible builds set SOURCE_DATE_EPOCH to the date of the last commit


### PR DESCRIPTION
When not passing a version of Python for pipenv to use, it seems to prefer to use the newest version available on the path.

The result is for the Python 3.7 build it was actually using the Python 3.8 installed on the ubuntu image instead (e.g. https://github.com/dls-controls/scanspec/runs/2166966041?check_suite_focus=true):
` Using /usr/bin/python3.8 (3.8.5) to create virtualenv...`

Adding --python with the explicit version defined in the matrix fixes this for 3.7: https://github.com/dls-controls/scanspec/runs/2175069600?check_suite_focus=true - whilst also not affecting the 3.8 and 3.9 builds.