### PR TITLE
GitHub Actions: enforce Python3.7 for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install pipenv
-          pipenv install --dev --deploy && pipenv graph
+          pipenv install --dev --deploy --python $(which python) && pipenv graph
 
       - name: Deploy index
         # We pin to the SHA, not the tag, for security reasons.


### PR DESCRIPTION
The setup-python action sets python alias to the version specific in the action.

This change enforces pipenv to use this version of python instead of the newest python available on the path.