### PR TITLE
GitHub Actions: make pipenv install consistent for docs and code

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           env
           pip install pipenv
-          pipenv install --dev --deploy --python ${{ matrix.python }} && pipenv graph
+          pipenv install --dev --deploy --python $(which python) && pipenv graph
 
       - name: Create Sdist and Wheel
         # for reproducible builds set SOURCE_DATE_EPOCH to the date of the last commit


### PR DESCRIPTION
Makes the GitHub Actions workflows use the same args for pipenv.