### PR TITLE
Bump apischema version

### DIFF
--- a/scanspec/sphinxext.py
+++ b/scanspec/sphinxext.py
@@ -66,8 +66,9 @@ def get_description(meta: Any) -> str:
     additional = []
     for arg in meta[1:]:
         arg = arg.get(SCHEMA_METADATA, arg)
-        if type(arg) == Schema:
-            field_schema = arg.as_dict()
+        if isinstance(arg, Schema):
+            field_schema: Dict[str, Any] = {}
+            arg.merge_into(field_schema)
             for key, value in field_schema.items():
                 if key == "description":
                     description = value

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     # make sure a python 3.9 compatible numpy is selected
     numpy>=1.19.3
     click
-    apischema>=0.14.7
+    apischema>=0.15.1
     typing_extensions
 
 [options.extras_require]


### PR DESCRIPTION
Author of *apischema* here.

Actually, the solution I'd given in https://github.com/wyfo/apischema/discussions/56 for your tagged union use case was not a good one. In fact, the serialization  part was working because of the side-effect of a bug present in v0.14. I've released v0.15 today and the bug has been fixed, so it should not work anymore with recent *apischema* versions.

Hopefully, v0.15.0 also comes with a lot of improvements, especially when it comes to serialization. Indeed, because *apischema* now uses type annotations for serialization, it's possible to register a conversion only for a base class, and this conversion can be used if the base class is passed as `serialize` new type parameter. Registering a serialization for each `Spec` subclass is no more needed, as every fields of type `Spec` will be serialized using the `Spec` serialization as tagged union.

The use case is now documented in *apischema* documentation [example](https://wyfo.github.io/apischema/examples/subclass_tagged_union/).

Because I'm quite ashamed of having led you to a faulty implementation, I've done this PR to bump *apischema* version and fix the implementation at the same time.