### PR TITLE
Wyfo bump apischema

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -54,7 +54,6 @@
                 "sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a",
                 "sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.7.4.post0"
         },
         "aiohttp-cors": {
@@ -66,18 +65,16 @@
         },
         "apischema": {
             "hashes": [
-                "sha256:01e20de70efa4885af918b9ce1ceaacc1952897624311512395a4bb379921571",
-                "sha256:047a5a84fc1a33af8b7538d1fdeaece9c049ebf6eced8a018ea77d6c6b44a415"
+                "sha256:07b796020fa647915c88ae82e4e8f416ed39a33d9228537f745964733f00160c",
+                "sha256:3536e82aca40846769455d5c675a72c800953516cf730dfa791fc5c12f2cd04e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.14.7"
+            "version": "==0.15.1"
         },
         "async-timeout": {
             "hashes": [
                 "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
                 "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
             ],
-            "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
         },
         "attrs": {
@@ -85,7 +82,6 @@
                 "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
                 "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
         "chardet": {
@@ -93,7 +89,6 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "click": {
@@ -101,7 +96,6 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "cycler": {
@@ -116,7 +110,6 @@
                 "sha256:2ae62ed27eb5c629fdfd06f89bec36a427bef97d37aef41e8f195c5352f22bea",
                 "sha256:972eff18416ad90815c95914b754486270f13fbe1a24e010c7eedbaa903b9386"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==3.1.4"
         },
         "graphql-server": {
@@ -170,7 +163,6 @@
                 "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05",
                 "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.3.1"
         },
         "matplotlib": {
@@ -195,7 +187,6 @@
                 "sha256:be4430b33b25e127fc4ea239cc386389de420be4d63e71d5359c20b562951ce1",
                 "sha256:c45e7bf89ea33a2adaef34774df4e692c7436a18a48bcb0e47a53e698a39fa39"
             ],
-            "markers": "python_version >= '3.7'",
             "version": "==3.4.1"
         },
         "multidict": {
@@ -238,7 +229,6 @@
                 "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
                 "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
         "numpy": {
@@ -268,7 +258,6 @@
                 "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935",
                 "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"
             ],
-            "markers": "python_version >= '3.7'",
             "version": "==1.20.2"
         },
         "pillow": {
@@ -307,7 +296,6 @@
                 "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
                 "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==8.2.0"
         },
         "pyparsing": {
@@ -315,7 +303,6 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -323,7 +310,6 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "scanspec": {
@@ -356,7 +342,6 @@
                 "sha256:f68eb46b86b2c246af99fcaa6f6e37c7a7a413e1084a794990b877f2ff71f7b6",
                 "sha256:fdf606341cd798530b05705c87779606fcdfaf768a8129c348ea94441da15b04"
             ],
-            "markers": "python_version < '3.10' and python_version >= '3.7'",
             "version": "==1.6.3"
         },
         "six": {
@@ -364,7 +349,6 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "typing-extensions": {
@@ -416,7 +400,6 @@
                 "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
                 "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.6.3"
         }
     },
@@ -448,7 +431,6 @@
                 "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
                 "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
         "babel": {
@@ -478,7 +460,6 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "click": {
@@ -486,7 +467,6 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "coverage": {
@@ -594,7 +574,7 @@
                 "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581",
                 "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==4.0.1"
         },
         "iniconfig": {
@@ -753,7 +733,6 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -983,10 +962,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
-                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
+                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
             ],
-            "version": "==1.26.4"
+            "version": "==1.26.5"
         },
         "zipp": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -65,10 +65,10 @@
         },
         "apischema": {
             "hashes": [
-                "sha256:07b796020fa647915c88ae82e4e8f416ed39a33d9228537f745964733f00160c",
-                "sha256:3536e82aca40846769455d5c675a72c800953516cf730dfa791fc5c12f2cd04e"
+                "sha256:01b6dab6bebd2ea1c618c3831a3723ae8b1b38139816cb9c1a8f75d7b46c9047",
+                "sha256:9e2bd77429bfc92087f58264f5689e605961acb691349f4524b28b6de8d8de83"
             ],
-            "version": "==0.15.1"
+            "version": "==0.15.2"
         },
         "async-timeout": {
             "hashes": [

--- a/scanspec/core.py
+++ b/scanspec/core.py
@@ -80,7 +80,8 @@ def as_tagged_union(cls: Cls) -> Cls:
             exec_body=lambda ns: ns.update(
                 {
                     "__annotations__": {
-                        sub.__name__: Tagged[sub] for sub in rec_subclasses(cls)  # type: ignore
+                        sub.__name__: Tagged[sub]  # type: ignore
+                        for sub in rec_subclasses(cls)
                     }
                 }
             ),
@@ -95,8 +96,8 @@ def as_tagged_union(cls: Cls) -> Cls:
         )
 
     def deserialization() -> Conversion:
-        annotations: dict[str, Any] = {}
-        deserialization_namespace: dict[str, Any] = {"__annotations__": annotations}
+        annotations: Dict[str, Any] = {}
+        deserialization_namespace: Dict[str, Any] = {"__annotations__": annotations}
         for sub in rec_subclasses(cls):
             annotations[sub.__name__] = Tagged[sub]  # type: ignore
             # Add tagged fields for all its alternative constructors

--- a/scanspec/plot.py
+++ b/scanspec/plot.py
@@ -40,7 +40,7 @@ class _Arrow3D(patches.FancyArrowPatch):
 
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         super().draw(renderer)
 

--- a/scanspec/plot.py
+++ b/scanspec/plot.py
@@ -40,7 +40,7 @@ class _Arrow3D(patches.FancyArrowPatch):
 
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.axes.M)
+        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         super().draw(renderer)
 

--- a/scanspec/sphinxext.py
+++ b/scanspec/sphinxext.py
@@ -66,8 +66,9 @@ def get_description(meta: Any) -> str:
     additional = []
     for arg in meta[1:]:
         arg = arg.get(SCHEMA_METADATA, arg)
-        if type(arg) == Schema:
-            field_schema = arg.as_dict()
+        if isinstance(arg, Schema):
+            field_schema: Dict[str, Any] = {}
+            arg.merge_into(field_schema)
             for key, value in field_schema.items():
                 if key == "description":
                     description = value

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     # make sure a python 3.9 compatible numpy is selected
     numpy>=1.19.3
     click
-    apischema>=0.14.7
+    apischema>=0.15.1
     typing_extensions
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     # make sure a python 3.9 compatible numpy is selected
     numpy>=1.19.3
     click
-    apischema>=0.15.1
+    apischema>=0.15.2
     typing_extensions
 
 [options.extras_require]


### PR DESCRIPTION
Supercedes #21 

@wyfo there is one possible regression, if I deserialize from a dict with an int into a dataclass with a float, the dataclass contains an int. Is this expected?

```python
>>> from dataclasses import dataclass
>>> from apischema import deserialize
>>> @dataclass
... class A:
...     b: float
... 
>>> deserialize(A, {"b": 3})
A(b=3)
>>> deserialize(A, {"b": 3.0})
A(b=3.0)
>>> deserialize(A, {"b": "3"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/scratch/tmc43/pipenv/scanspec-mSoGTI3w/lib/python3.7/site-packages/apischema/utils.py", line 540, in wrapper
    return wrapped(*args, **kwargs)
  File "/scratch/tmc43/pipenv/scanspec-mSoGTI3w/lib/python3.7/site-packages/apischema/deserialization/__init__.py", line 876, in deserialize
    )(data)
  File "/scratch/tmc43/pipenv/scanspec-mSoGTI3w/lib/python3.7/site-packages/apischema/deserialization/__init__.py", line 528, in method
    raise ValidationError(errors, field_errors)
apischema.validation.errors.ValidationError: ValidationError(messages=[], children={'b': ValidationError(messages=['expected type number, found string'], children={})})
```