### PR TITLE
Add helper factory method to Static spec to create a scan with no motion, rename TIME dimension to DURATION

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -65,10 +65,10 @@
         },
         "apischema": {
             "hashes": [
-                "sha256:01b6dab6bebd2ea1c618c3831a3723ae8b1b38139816cb9c1a8f75d7b46c9047",
-                "sha256:9e2bd77429bfc92087f58264f5689e605961acb691349f4524b28b6de8d8de83"
+                "sha256:6c6a8ea1278767140f3807b03cd9986ebe9baf1deb7aba3724504f2410644a45",
+                "sha256:7543fd50405154f8268323af4b8c0f74b9f6613c56051049ca7aa0fd5f115f9e"
             ],
-            "version": "==0.15.2"
+            "version": "==0.15.5"
         },
         "async-timeout": {
             "hashes": [
@@ -346,10 +346,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "version": "==1.15.0"
+            "version": "==1.16.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -450,10 +450,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "chardet": {
             "hashes": [
@@ -571,11 +571,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581",
-                "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"
+                "sha256:4a5611fea3768d3d967c447ab4e93f567d95db92225b43b7b238dbfb855d70bb",
+                "sha256:c6513572926a96458f8c8f725bf0e00108fba0c9583ade9bd15b869c9d726e33"
             ],
             "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==4.0.1"
+            "version": "==4.6.0"
         },
         "iniconfig": {
             "hashes": [
@@ -606,8 +606,12 @@
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -616,24 +620,39 @@
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
                 "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
                 "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
                 "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
                 "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
                 "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
                 "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
                 "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
                 "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
                 "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
                 "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
                 "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
                 "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
             ],
             "version": "==1.1.1"
         },
@@ -646,31 +665,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e",
-                "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064",
-                "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c",
-                "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4",
-                "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97",
-                "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df",
-                "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8",
-                "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a",
-                "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56",
-                "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7",
-                "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6",
-                "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5",
-                "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a",
-                "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521",
-                "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564",
-                "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49",
-                "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66",
-                "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a",
-                "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119",
-                "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506",
-                "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c",
-                "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"
+                "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
+                "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a",
+                "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9",
+                "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e",
+                "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2",
+                "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212",
+                "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b",
+                "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885",
+                "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150",
+                "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703",
+                "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072",
+                "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457",
+                "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e",
+                "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0",
+                "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb",
+                "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97",
+                "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8",
+                "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811",
+                "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6",
+                "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de",
+                "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504",
+                "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
+                "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
             ],
             "index": "pypi",
-            "version": "==0.812"
+            "version": "==0.910"
         },
         "mypy-extensions": {
             "hashes": [
@@ -949,6 +969,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
+            "markers": "python_version < '3.8'",
             "version": "==1.4.3"
         },
         "typing-extensions": {

--- a/scanspec/plot.py
+++ b/scanspec/plot.py
@@ -9,7 +9,7 @@ from scipy import interpolate
 
 from .core import Dimension, Path
 from .regions import Circle, Ellipse, Polygon, Rectangle, find_regions
-from .specs import TIME, Spec
+from .specs import DURATION, Spec
 
 __all__ = ["plot_spec"]
 
@@ -100,7 +100,7 @@ def plot_spec(spec: Spec):
     """
     dims = spec.create_dimensions()
     dim = Path(dims).consume()
-    axes = [a for a in spec.axes() if a is not TIME]
+    axes = [a for a in spec.axes() if a is not DURATION]
     ndims = len(axes)
 
     # Setup axes

--- a/scanspec/specs.py
+++ b/scanspec/specs.py
@@ -29,7 +29,7 @@ __all__ = [
     "Line",
     "Static",
     "Spiral",
-    "TIME",
+    "DURATION",
     "REPEAT",
     "fly",
     "step",
@@ -38,7 +38,7 @@ __all__ = [
 
 
 #: Can be used as a special key to indicate how long each point should be
-TIME = "TIME"
+DURATION = "DURATION"
 
 
 #: Can be used as a special key to indicate repeats of a whole spec
@@ -484,7 +484,7 @@ class Static(Spec):
             spec = Static.duration(0.5, 16)
         """
 
-        return cls(TIME, duration, num)
+        return cls(DURATION, duration, num)
 
     def axes(self) -> List:
         return [self.axis]

--- a/scanspec/specs.py
+++ b/scanspec/specs.py
@@ -472,7 +472,7 @@ class Static(Spec):
 
     @classmethod
     def duration(cls, duration: float, num: int = 1) -> Spec:
-        """A static spec with no motion, only a duration repeated `num` times
+        """A static spec with no motion, only a duration repeated "num" times
         Args:
             duration: The duration of each static point
             num: Number of points to produce with given duration

--- a/scanspec/specs.py
+++ b/scanspec/specs.py
@@ -476,12 +476,6 @@ class Static(Spec):
         Args:
             duration: The duration of each static point
             num: Number of points to produce with given duration
-
-        .. example_spec::
-
-            from scanspec.specs import Static
-
-            spec = Static.duration(0.5, 16)
         """
 
         return cls(DURATION, duration, num)

--- a/scanspec/specs.py
+++ b/scanspec/specs.py
@@ -606,7 +606,7 @@ def fly(spec: Spec, duration: float) -> Spec:
 
         spec = fly(Line("x", 1, 2, 3), 0.1)
     """
-    return spec + Static(TIME, duration)
+    return spec + Static.duration(duration)
 
 
 def step(spec: Spec, duration: float, num: int = 1) -> Spec:
@@ -625,7 +625,7 @@ def step(spec: Spec, duration: float, num: int = 1) -> Spec:
 
         spec = step(Line("x", 1, 2, 3), 0.1)
     """
-    return spec * Static(TIME, duration, num)
+    return spec * Static.duration(duration, num)
 
 
 def repeat(spec: Spec, num: int, blend=False) -> Spec:

--- a/scanspec/specs.py
+++ b/scanspec/specs.py
@@ -37,6 +37,14 @@ __all__ = [
 ]
 
 
+#: Can be used as a special key to indicate how long each point should be
+TIME = "TIME"
+
+
+#: Can be used as a special key to indicate repeats of a whole spec
+REPEAT = "REPEAT"
+
+
 @dataclass
 class Spec(Serializable):
     """Definition: A spec is a serializable representation of the type, parameters
@@ -462,6 +470,22 @@ class Static(Spec):
         metadata=schema(min=1, description="How many times to repeat this point"),
     )
 
+    @classmethod
+    def duration(cls, duration: float, num: int = 1) -> Spec:
+        """A static spec with no motion, only a duration repeated `num` times
+        Args:
+            duration: The duration of each static point
+            num: Number of points to produce with given duration
+
+        .. example_spec::
+
+            from scanspec.specs import Static
+
+            spec = Static.duration(0.5, 16)
+        """
+
+        return cls(TIME, duration, num)
+
     def axes(self) -> List:
         return [self.axis]
 
@@ -569,14 +593,6 @@ class Spiral(Spec):
         )
 
 
-#: Can be used as a special key to indicate how long each point should be
-TIME = "TIME"
-
-
-#: Can be used as a special key to indicate repeats of a whole spec
-REPEAT = "REPEAT"
-
-
 def fly(spec: Spec, duration: float) -> Spec:
     """Flyscan, zipping TIME=duration for every frame
 
@@ -593,7 +609,7 @@ def fly(spec: Spec, duration: float) -> Spec:
     return spec + Static(TIME, duration)
 
 
-def step(spec: Spec, duration: float, num: int = 1):
+def step(spec: Spec, duration: float, num: int = 1) -> Spec:
     """Step scan, adding num x TIME=duration as an inner dimension for
     every midpoint
 
@@ -612,7 +628,7 @@ def step(spec: Spec, duration: float, num: int = 1):
     return spec * Static(TIME, duration, num)
 
 
-def repeat(spec: Spec, num: int, blend=False):
+def repeat(spec: Spec, num: int, blend=False) -> Spec:
     """Repeat spec num times
 
     Args:

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -3,7 +3,7 @@ import pytest
 from scanspec.core import Path
 from scanspec.regions import Circle, Ellipse, Polygon, Rectangle
 from scanspec.specs import (
-    TIME,
+    DURATION,
     Concat,
     Line,
     Mask,
@@ -21,9 +21,9 @@ x, y, z = "x", "y", "z"
 def test_one_point_duration() -> None:
     duration = Static.duration(1.0)
     (dim,) = duration.create_dimensions()
-    assert dim.midpoints == {TIME: pytest.approx([1.0])}
-    assert dim.lower == {TIME: pytest.approx([1.0])}
-    assert dim.upper == {TIME: pytest.approx([1.0])}
+    assert dim.midpoints == {DURATION: pytest.approx([1.0])}
+    assert dim.lower == {DURATION: pytest.approx([1.0])}
+    assert dim.upper == {DURATION: pytest.approx([1.0])}
     assert dim.snake is False
 
 
@@ -48,15 +48,26 @@ def test_two_point_stepped_line() -> None:
     inst = step(Line(x, 0, 1, 2), 0.1)
     dimx, dimt = inst.create_dimensions()
     assert dimx.midpoints == dimx.lower == dimx.upper == {x: pytest.approx([0, 1])}
-    assert dimt.midpoints == dimt.lower == dimt.upper == {TIME: pytest.approx([0.1])}
+    assert (
+        dimt.midpoints == dimt.lower == dimt.upper == {DURATION: pytest.approx([0.1])}
+    )
 
 
 def test_two_point_fly_line() -> None:
     inst = fly(Line(x, 0, 1, 2), 0.1)
     (dim,) = inst.create_dimensions()
-    assert dim.midpoints == {x: pytest.approx([0, 1]), TIME: pytest.approx([0.1, 0.1])}
-    assert dim.lower == {x: pytest.approx([-0.5, 0.5]), TIME: pytest.approx([0.1, 0.1])}
-    assert dim.upper == {x: pytest.approx([0.5, 1.5]), TIME: pytest.approx([0.1, 0.1])}
+    assert dim.midpoints == {
+        x: pytest.approx([0, 1]),
+        DURATION: pytest.approx([0.1, 0.1]),
+    }
+    assert dim.lower == {
+        x: pytest.approx([-0.5, 0.5]),
+        DURATION: pytest.approx([0.1, 0.1]),
+    }
+    assert dim.upper == {
+        x: pytest.approx([0.5, 1.5]),
+        DURATION: pytest.approx([0.1, 0.1]),
+    }
 
 
 def test_many_point_line() -> None:
@@ -177,13 +188,13 @@ def test_squashed_multiplied_snake_scan() -> None:
     inst = Line(z, 1, 2, 2) * Squash(
         Line(y, 1, 2, 2) * ~Line.bounded(x, 3, 7, 2) * Static.duration(9, 2)
     )
-    assert inst.axes() == [z, y, x, TIME]
+    assert inst.axes() == [z, y, x, DURATION]
     dimz, dimxyt = inst.create_dimensions()
     for d in dimxyt.midpoints, dimxyt.lower, dimxyt.upper:
         assert d == {
             x: pytest.approx([4, 4, 6, 6, 6, 6, 4, 4]),
             y: pytest.approx([1, 1, 1, 1, 2, 2, 2, 2]),
-            TIME: pytest.approx([9, 9, 9, 9, 9, 9, 9, 9]),
+            DURATION: pytest.approx([9, 9, 9, 9, 9, 9, 9, 9]),
         }
     assert dimz.midpoints == dimz.lower == dimz.upper == {z: pytest.approx([1, 2])}
 

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -18,6 +18,15 @@ from scanspec.specs import (
 x, y, z = "x", "y", "z"
 
 
+def test_one_point_duration() -> None:
+    duration = Static.duration(1.0)
+    (dim,) = duration.create_dimensions()
+    assert dim.midpoints == {TIME: pytest.approx([1.0])}
+    assert dim.lower == {TIME: pytest.approx([1.0])}
+    assert dim.upper == {TIME: pytest.approx([1.0])}
+    assert dim.snake is False
+
+
 def test_one_point_line() -> None:
     inst = Line(x, 0, 1, 1)
     (dim,) = inst.create_dimensions()

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -175,7 +175,7 @@ def test_squashed_product() -> None:
 
 def test_squashed_multiplied_snake_scan() -> None:
     inst = Line(z, 1, 2, 2) * Squash(
-        Line(y, 1, 2, 2) * ~Line.bounded(x, 3, 7, 2) * Static(TIME, 9, 2)
+        Line(y, 1, 2, 2) * ~Line.bounded(x, 3, 7, 2) * Static.duration(9, 2)
     )
     assert inst.axes() == [z, y, x, TIME]
     dimz, dimxyt = inst.create_dimensions()


### PR DESCRIPTION
The `Static` spec can be used to create a scan that involves no axes except for `TIME` via `Static(TIME, duration, num)`, this translates to "do nothing for `duration` seconds `num` times". This PR adds a helper method to do this without having to refer to `TIME`, it can be used like so:

```python
spec = Static.duration(duration, num)
```

This PR also renames `TIME` to `DURATION` since `TIME` implies absolute time when the axis is used to refer to the relative time from the start of a particular point.
