### PR TITLE
Remove restrictions on axis order for concatenation

### DIFF
--- a/src/scanspec/core.py
+++ b/src/scanspec/core.py
@@ -299,18 +299,21 @@ class Frames(Generic[Axis]):
     def concat(self, other: Frames[Axis], gap: bool = False) -> Frames[Axis]:
         """Return a new Frames object concatenating self and other.
 
-        Requires both Frames objects to have the same axes.
+        Requires both Frames objects to have the same axes, but not necessarily in
+        the same order. The order is inherited from self, so other may be reordered.
 
         Args:
             other: The Frames to concatenate to self
             gap: Whether to force a gap between the two Frames objects
 
-        >>> frames = Frames({"x": np.array([1, 2, 3])})
-        >>> frames2 = Frames({"x": np.array([5, 6, 7])})
+        >>> frames = Frames({"x": np.array([1, 2, 3]), "y": np.array([6, 5, 4])})
+        >>> frames2 = Frames({"y": np.array([3, 2, 1]), "x": np.array([4, 5, 6])})
         >>> frames.concat(frames2).midpoints
-        {'x': array([1, 2, 3, 5, 6, 7])}
+        {'x': array([1, 2, 3, 4, 5, 6]), 'y': array([6, 5, 4, 3, 2, 1])}
         """
-        assert self.axes() == other.axes(), f"axes {self.axes()} != {other.axes()}"
+        assert set(self.axes()) == set(
+            other.axes()
+        ), f"axes {self.axes()} != {other.axes()}"
 
         def concat_dict(ds: Sequence[AxesPoints[Axis]]) -> AxesPoints[Axis]:
             # Concat each array in midpoints, lower, upper. E.g.
@@ -433,7 +436,11 @@ class SnakedFrames(Frames[Axis]):
             }
         if self.midpoints is not self.upper:
             kwargs["upper"] = {
-                k: np.where(backwards, self.lower[k][snake_indices], v[snake_indices],)
+                k: np.where(
+                    backwards,
+                    self.lower[k][snake_indices],
+                    v[snake_indices],
+                )
                 for k, v in self.upper.items()
             }
 

--- a/src/scanspec/specs.py
+++ b/src/scanspec/specs.py
@@ -386,7 +386,9 @@ class Concat(Spec[Axis]):
 
     def axes(self) -> List:
         left_axes, right_axes = self.left.axes(), self.right.axes()
-        assert left_axes == right_axes, f"axes {left_axes} != {right_axes}"
+        # Assuming the axes are the same, the order does not matter, we inherit the
+        # order from the left-hand side. See also scanspec.core.concat.
+        assert set(left_axes) == set(right_axes), f"axes {left_axes} != {right_axes}"
         return left_axes
 
     def calculate(self, bounds=True, nested=False) -> List[Frames[Axis]]:
@@ -626,7 +628,8 @@ class Spiral(Spec[Axis]):
         radius: A[float, schema(description="radius of the spiral")],
         dr: A[float, schema(description="difference between each ring")],
         rotate: A[
-            float, schema(description="How much to rotate the angle of the spiral"),
+            float,
+            schema(description="How much to rotate the angle of the spiral"),
         ] = 0.0,
     ) -> Spiral[Axis]:
         """Specify a Spiral equally spaced in "x_axis" and "y_axis".
@@ -644,7 +647,14 @@ class Spiral(Spec[Axis]):
         n_rings = radius / dr
         num = int(n_rings ** 2 * np.pi)
         return Spiral(
-            x_axis, y_axis, x_start, y_start, radius * 2, radius * 2, num, rotate,
+            x_axis,
+            y_axis,
+            x_start,
+            y_start,
+            radius * 2,
+            radius * 2,
+            num,
+            rotate,
         )
 
 


### PR DESCRIPTION
Allow concatenating `Frames` and `Spec` obejcts with axes in different orders, so long as the set of axes is the same. Order is inherited from the lefthand side.

```python
# Valid, no change
Concat(Line("x", 0, 10, 10), Line("x", 10, 20, 10))

# Valid, no change
Concat(Line("x", 0, 10, 10) * Line("y", 0, 10, 10), Line("x", 10, 20, 10) * Line("y", 0, 20, 10))

# Valid, axis order is ["x", "y"]
Concat(Line("y", 0, 10, 10) * Line("x", 0, 10, 10), Line("x", 10, 20, 10) * Line("y", 0, 20, 10))

# Invalid, axes are not the same
Concat(Line("y", 0, 10, 10) * Line("x", 0, 10, 10) * Line("z", 0, 10, 10), Line("x", 10, 20, 10) * Line("y", 0, 20, 10))
```

We currently consider this reasonable because nothing downstream depends on knowing the order, so it is reasonable to abstract the information away in exchange for flexibility. Unsure if this will change though.