### PR TITLE
Add shape utility method to Spec to get a scan's simplified shape

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ service = ["fastapi", "uvicorn"]
 # For development tests/docs
 dev = [
     "black==22.3.0",
-    "mypy",
+    "mypy<1",
     "flake8-isort",
     "Flake8-pyproject",
     "pipdeptree",

--- a/src/scanspec/specs.py
+++ b/src/scanspec/specs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, Type
+from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, Tuple, Type
 
 import numpy as np
 from pydantic import Field, parse_obj_as
@@ -76,6 +76,10 @@ class Spec(Generic[Axis]):
     def midpoints(self) -> Midpoints[Axis]:
         """Return `Midpoints` that can be iterated point by point."""
         return Midpoints(self.calculate(bounds=False))
+
+    def shape(self) -> Tuple[int, ...]:
+        """Return the final, simplified shape of the scan."""
+        return tuple(len(dim) for dim in self.calculate())
 
     def __rmul__(self, other) -> Product[Axis]:
         return if_instance_do(other, int, lambda o: Product(Repeat(o), self))

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 
 import pytest
 
@@ -14,6 +14,7 @@ from scanspec.specs import (
     Spiral,
     Squash,
     Static,
+    Zip,
     fly,
     step,
 )
@@ -527,3 +528,33 @@ def test_multiple_statics_with_grid():
         {"x": 10.0, "y": 10.0, "a": 4, "b": 5},
     ]
     assert spec.frames().gap == ints("10101010")
+
+
+@pytest.mark.parametrize(
+    "spec,expected_shape",
+    [
+        (Line("x", 0.0, 1.0, 1), (1,)),
+        (Line("x", 0.0, 1.0, 5), (5,)),
+        (Spiral("x", "y", 0.0, 0.0, 1.0, 1.0, 5, 0.0), (5,)),
+        (Line("x", 0.0, 1.0, 2) * Line("y", 0.0, 1.0, 2), (2, 2)),
+        (Squash(Line("x", 0.0, 1.0, 2) * Line("y", 0.0, 1.0, 2)), (4,)),
+        (Zip(Line("x", 0.0, 1.0, 2), Line("y", 0.0, 1.0, 2)), (2,)),
+        (Concat(Line("x", 0.0, 1.0, 2), Line("x", 0.0, 1.0, 2)), (4,)),
+        (
+            Line("x", 0.0, 1.0, 2) * Line("y", 0.0, 1.0, 2) * Line("z", 0.0, 2.0, 2),
+            (2, 2, 2),
+        ),
+        (
+            Zip(Line("x", 0.0, 1.0, 2), Line("y", 0.0, 1.0, 2))
+            * Line("z", 0.0, 2.0, 2),
+            (2, 2),
+        ),
+        (
+            Concat(Line("x", 0.0, 1.0, 2), Line("x", 0.0, 1.0, 2))
+            * Line("z", 0.0, 2.0, 2),
+            (4, 2),
+        ),
+    ],
+)
+def test_shape(spec: Spec, expected_shape: Tuple[int, ...]):
+    assert expected_shape == spec.shape()


### PR DESCRIPTION
* Add `Spec.shape()` method which gives the the number of dimensions in the scan in the simplest possible view
* Add tests for shape method