### PR TITLE
Temporarily pin more dependencies to allow release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 description = "Specify step and flyscan paths in a serializable, efficient and Pythonic way"
 dependencies = [
     "numpy>=1.19.3",
-    "click",
+    "click==8.1.3",
     "pydantic<2.0",
     "typing_extensions"
 ]
@@ -32,7 +32,10 @@ plotting = [
     "matplotlib>=3.2.2",
 ]
 # REST service support
-service = ["fastapi", "uvicorn"]
+service = [
+    "fastapi==0.99",
+    "uvicorn"
+]
 # For development tests/docs
 dev = [
     "black==22.3.0",


### PR DESCRIPTION
- Click 8.1.4 typechecking incompatible with mypy configuration, temporarily pinned until https://github.com/pallets/click/issues/2558 resolved
- FastApi 0.99 supports OpenAPI 3.1 and changes examples syntax, while 0.100 adopts Pydantic2.0. Pin to 0.99 until moving to Pydantic 2.0