### PR TITLE
Bugfix linearsource scanspecv2

### DIFF
--- a/src/scanspec2/core.py
+++ b/src/scanspec2/core.py
@@ -83,10 +83,14 @@ class LinearSource(Generic[AxisT]):
         """Evaluate linear positions at *indexes*."""
         result: dict[AxisT, np.ndarray] = {}
         for ax, (start, stop) in self.axis_ranges.items():
-            if self._length <= 1:
-                step = stop - start
+            # If inquired for a single index the step size is
+            # the distance normalized by the original lenght.
+            if len(indexes) <= 1:
+                step = (stop - start) / self._length
+            # If inquired for multiple indexes step size becomes
+            # the original range normalized over the number of indexes.
             else:
-                step = (stop - start) / (self._length - 1)
+                step = (stop - start) / (len(indexes) - 1)
             first = start - step / 2
             result[ax] = first + indexes * step
         return result

--- a/src/scanspec2/core.py
+++ b/src/scanspec2/core.py
@@ -90,7 +90,7 @@ class LinearSource(Generic[AxisT]):
             # If inquired for multiple indexes step size becomes
             # the original range normalized over the number of indexes.
             else:
-                step = (stop - start) / (len(indexes) - 1)
+                step = (stop - start) / (len(indexes))
             first = start - step / 2
             result[ax] = first + indexes * step
         return result

--- a/src/scanspec2/core.py
+++ b/src/scanspec2/core.py
@@ -89,8 +89,13 @@ class LinearSource(Generic[AxisT]):
                 step = (stop - start) / self._length
             # If inquired for multiple indexes step size becomes
             # the original range normalized over the number of indexes.
+            # It's also necessary to add two extra points:
+            # *One point for the first lower bound
+            # *One point for the last upper bound
+            # result[ax][N] - result[ax][N-1] -> should return the midpoint
             else:
                 step = (stop - start) / (len(indexes))
+                indexes = np.arange(0, len(indexes) + 2, 1)
             first = start - step / 2
             result[ax] = first + indexes * step
         return result

--- a/tests/scanspec2/__init__.py
+++ b/tests/scanspec2/__init__.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import pytest
+
+
+def approx(
+    expected: Any,
+    rel: float | None = None,
+    abs: float | None = None,
+    nan_ok: bool = False,
+) -> Any:
+    """
+    Temporary loosely typed wrapper around approx.
+    To be removed pending:
+    https://github.com/pytest-dev/pytest/issues/7469
+
+    Args:
+        expected: Expected value
+        rel: Relative tolerance. Defaults to None.
+        abs: Absolute tolerance. Defaults to None.
+        nan_ok: Permit nan. Defaults to False.
+
+    Returns:
+        Any: Approximate comparator
+    """
+
+    return pytest.approx(expected, rel=rel, abs=abs, nan_ok=nan_ok)  # type: ignore

--- a/tests/scanspec2/test_compile.py
+++ b/tests/scanspec2/test_compile.py
@@ -25,8 +25,6 @@ from scanspec2.specs import (
     Static,
 )
 
-from . import approx
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1020,7 +1018,7 @@ def test_acquire_fly_scan_window_positions():
     # Detector with total acquisition time of 1s
     det = DetectorGroup(1, 10, 0.9, 0.1, ["spec_det1"])
     spec: Acquire[str, str, Never] = Acquire(
-        spec=Linspace("x", 0, 10, 10), fly=True, detectors=[det], stream_name="spec"
+        spec=Linspace("x", 11, 20, 10), fly=True, detectors=[det], stream_name="spec"
     )
     scan = spec.compile()
     ws = windows(scan)
@@ -1029,23 +1027,23 @@ def test_acquire_fly_scan_window_positions():
         # Return positions spaced 1s apart
         for p in w.positions(1, None):
             assert len(p["x"]) == 10
-            assert p["x"] == approx(
+            assert p["x"] == pytest.approx(  # type: ignore[reportUnknownMemberType]
                 [
-                    -0.55555556,
-                    0.67901235,
-                    1.91358025,
-                    3.14814815,
-                    4.38271605,
-                    5.61728395,
-                    6.85185185,
-                    8.08641975,
-                    9.32098765,
-                    10.55555556,
+                    10.55,
+                    11.55,
+                    12.55,
+                    13.55,
+                    14.55,
+                    15.55,
+                    16.55,
+                    17.55,
+                    18.55,
+                    19.55,
                 ]
             )
     det = DetectorGroup(1, 10, 1, 1, ["spec_det1"])
     spec: Acquire[str, str, Never] = Acquire(
-        spec=Linspace("x", 0, 10, 10), fly=True, detectors=[det], stream_name="spec"
+        spec=Linspace("x", 11, 20, 10), fly=True, detectors=[det], stream_name="spec"
     )
     scan = spec.compile()
     ws = windows(scan)
@@ -1054,28 +1052,28 @@ def test_acquire_fly_scan_window_positions():
         # Return positions spaced 1s apart
         for p in w.positions(1, None):
             assert len(p["x"]) == 20
-            assert p["x"] == approx(
+            assert p["x"] == pytest.approx(  # type: ignore[reportUnknownMemberType]
                 [
-                    -0.26315789,
-                    0.29085873,
-                    0.84487535,
-                    1.39889197,
-                    1.95290859,
-                    2.50692521,
-                    3.06094183,
-                    3.61495845,
-                    4.16897507,
-                    4.72299169,
-                    5.27700831,
-                    5.83102493,
-                    6.38504155,
-                    6.93905817,
-                    7.49307479,
-                    8.04709141,
-                    8.60110803,
-                    9.15512465,
-                    9.70914127,
-                    10.26315789,
+                    10.775,
+                    11.24868421,
+                    11.72236842,
+                    12.19605263,
+                    12.66973684,
+                    13.14342105,
+                    13.61710526,
+                    14.09078947,
+                    14.56447368,
+                    15.03815789,
+                    15.51184211,
+                    15.98552632,
+                    16.45921053,
+                    16.93289474,
+                    17.40657895,
+                    17.88026316,
+                    18.35394737,
+                    18.82763158,
+                    19.30131579,
+                    19.775,
                 ]
             )
 

--- a/tests/scanspec2/test_compile.py
+++ b/tests/scanspec2/test_compile.py
@@ -1026,19 +1026,21 @@ def test_acquire_fly_scan_window_positions():
     for w in ws:
         # Return positions spaced 1s apart
         for p in w.positions(1, None):
-            assert len(p["x"]) == 10
+            assert len(p["x"]) == 12
             assert p["x"] == pytest.approx(  # type: ignore[reportUnknownMemberType]
                 [
                     10.55,
-                    11.55,
-                    12.55,
-                    13.55,
-                    14.55,
-                    15.55,
-                    16.55,
-                    17.55,
-                    18.55,
+                    11.45,
+                    12.35,
+                    13.25,
+                    14.15,
+                    15.05,
+                    15.95,
+                    16.85,
+                    17.75,
+                    18.65,
                     19.55,
+                    20.45,
                 ]
             )
     det = DetectorGroup(1, 10, 1, 1, ["spec_det1"])
@@ -1051,29 +1053,31 @@ def test_acquire_fly_scan_window_positions():
     for w in ws:
         # Return positions spaced 1s apart
         for p in w.positions(1, None):
-            assert len(p["x"]) == 20
+            assert len(p["x"]) == 22
             assert p["x"] == pytest.approx(  # type: ignore[reportUnknownMemberType]
                 [
                     10.775,
-                    11.24868421,
-                    11.72236842,
-                    12.19605263,
-                    12.66973684,
-                    13.14342105,
-                    13.61710526,
-                    14.09078947,
-                    14.56447368,
-                    15.03815789,
-                    15.51184211,
-                    15.98552632,
-                    16.45921053,
-                    16.93289474,
-                    17.40657895,
-                    17.88026316,
-                    18.35394737,
-                    18.82763158,
-                    19.30131579,
+                    11.225,
+                    11.675,
+                    12.125,
+                    12.575,
+                    13.025,
+                    13.475,
+                    13.925,
+                    14.375,
+                    14.825,
+                    15.275,
+                    15.725,
+                    16.175,
+                    16.625,
+                    17.075,
+                    17.525,
+                    17.975,
+                    18.425,
+                    18.875,
+                    19.325,
                     19.775,
+                    20.225,
                 ]
             )
 

--- a/tests/scanspec2/test_compile.py
+++ b/tests/scanspec2/test_compile.py
@@ -25,6 +25,8 @@ from scanspec2.specs import (
     Static,
 )
 
+from . import approx
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1012,3 +1014,80 @@ def test_zip_rejects_monitors():
     )
     with pytest.raises(ValueError, match="Zip does not accept.*monitors"):
         Linspace("y", 0, 1, 5).zip(a).compile()  # type: ignore[reportArgumentType]
+
+
+def test_acquire_fly_scan_window_positions():
+    # Detector with total acquisition time of 1s
+    det = DetectorGroup(1, 10, 0.9, 0.1, ["spec_det1"])
+    spec: Acquire[str, str, Never] = Acquire(
+        spec=Linspace("x", 0, 10, 10), fly=True, detectors=[det], stream_name="spec"
+    )
+    scan = spec.compile()
+    ws = windows(scan)
+    assert len(ws) == 1
+    for w in ws:
+        # Return positions spaced 1s apart
+        for p in w.positions(1, None):
+            assert len(p["x"]) == 10
+            assert p["x"] == approx(
+                [
+                    -0.55555556,
+                    0.67901235,
+                    1.91358025,
+                    3.14814815,
+                    4.38271605,
+                    5.61728395,
+                    6.85185185,
+                    8.08641975,
+                    9.32098765,
+                    10.55555556,
+                ]
+            )
+    det = DetectorGroup(1, 10, 1, 1, ["spec_det1"])
+    spec: Acquire[str, str, Never] = Acquire(
+        spec=Linspace("x", 0, 10, 10), fly=True, detectors=[det], stream_name="spec"
+    )
+    scan = spec.compile()
+    ws = windows(scan)
+    assert len(ws) == 1
+    for w in ws:
+        # Return positions spaced 1s apart
+        for p in w.positions(1, None):
+            assert len(p["x"]) == 20
+            assert p["x"] == approx(
+                [
+                    -0.26315789,
+                    0.29085873,
+                    0.84487535,
+                    1.39889197,
+                    1.95290859,
+                    2.50692521,
+                    3.06094183,
+                    3.61495845,
+                    4.16897507,
+                    4.72299169,
+                    5.27700831,
+                    5.83102493,
+                    6.38504155,
+                    6.93905817,
+                    7.49307479,
+                    8.04709141,
+                    8.60110803,
+                    9.15512465,
+                    9.70914127,
+                    10.26315789,
+                ]
+            )
+
+
+def test_acquire_step_scan_window_positions():
+    det = DetectorGroup(1, 10, 1, 1, ["spec_det1"])
+    spec: Acquire[str, str, Never] = Acquire(
+        spec=Linspace("x", 0, 10, 10), fly=False, detectors=[det], stream_name="spec"
+    )
+    scan = spec.compile()
+    ws = windows(scan)
+    pos = np.linspace(0, 10, 10, endpoint=False)
+    assert len(ws) == 10
+    for w, p in zip(ws, pos, strict=True):
+        assert w.static_axes == {"x": p}


### PR DESCRIPTION
While testing ScanSpecV2 I noticed that if trying to create an `Acquire` spec with `fly=true` and then tried making this into a scan and parsing the windows the positional values returned by the windows would be out of the expected boundaries of my motion spec. I believe this is to do with how the `LinearSource` is defined where we have it use the original length passed to it to define the step size, independent of the size of the index passed in `setpoints`.
This PR tries to address this by changing the way the step size is calculated and by adding some Unit tests to it. 

Here's an example of the code I used to tests and find the initial problem:
```python:
from scanspec2.core import DetectorGroup
from scanspec2.specs import Acquire, Linspace, Static

det1 = DetectorGroup(1, 10, 1, 1, ["spec_det1"])
det2 = DetectorGroup(1, 1, 1, 1, ["spec_det2"])

spec = Acquire(
    spec=Linspace("x", 0, 10, 10), fly=True, detectors=[det1], stream_name="spec"
)
scan = spec.compile()

for window in scan:
    for axis in window.moving_axes:
        print(f"axis: {window.moving_axes}")
    for trig in window.trigger_groups:
        print(f"trig.detectors = {trig.detectors}")
        for pattern in trig.trigger_patterns:
            print(
                f"livetime = {pattern.livetime}\ndeadtime = {pattern.deadtime}\nrepeats = {pattern.repeats}\n"
            )
    for p in window.positions(1, None):
        print(f"pos = {p['x']}\nlen(pos) = {len(p['x'])}")

```